### PR TITLE
Fix crashes for big export (BigMaps, BitAddres over 32 bits)

### DIFF
--- a/pipeline/process/BigMap.ts
+++ b/pipeline/process/BigMap.ts
@@ -4,7 +4,7 @@ const MAX_MAP_SIZE = Math.pow(2, 24) - 1; // (-1 just in case)
 /**
  * A Map that can grow beyond the map size limit using multiple maps.
  */
-class BigMap<K, V> {
+export class BigMap<K, V> {
     private maps: Map<K, V>[] = [new Map()];
 
     private get lastMap() {

--- a/pipeline/process/BigMap.ts
+++ b/pipeline/process/BigMap.ts
@@ -1,0 +1,33 @@
+// In V8, the maximum size of a Map is 2^24
+const MAX_MAP_SIZE = Math.pow(2, 24) - 1; // (-1 just in case)
+
+/**
+ * A Map that can grow beyond the map size limit using multiple maps.
+ */
+class BigMap<K, V> {
+    private maps: Map<K, V>[] = [new Map()];
+
+    private get lastMap() {
+        return this.maps[this.maps.length - 1];
+    }
+
+    set(key: K, value: V) {
+        if (this.lastMap.size >= MAX_MAP_SIZE) {
+            this.maps.push(new Map());
+        }
+        this.lastMap.set(key, value);
+    }
+
+    get(key: K): V | undefined {
+        // go backwards to ensure that the most recent values are returned first
+        for (let i = this.maps.length - 1; i >= 0; i--) {
+            const value = this.maps[i].get(key);
+            if (value !== undefined) {
+                return value;
+            }
+        }
+        return undefined;
+    }
+
+    // TODO: add more functionality as needed
+}

--- a/pipeline/process/DatabaseBuilder.ts
+++ b/pipeline/process/DatabaseBuilder.ts
@@ -351,7 +351,7 @@ export class DatabaseBuilder {
             domainsIdxBits: numBitsFor(this.domains.size),
         };
         const finalMessages = new MessagesArray(bitConfig);
-        const messageAddresses = new Map<RawID, BitAddress>();
+        const messageAddresses = new BigMap<RawID, BitAddress>();
 
         const totalMessages = this.numMessages;
         let alreadyCounted = 0;

--- a/pipeline/process/DatabaseBuilder.ts
+++ b/pipeline/process/DatabaseBuilder.ts
@@ -6,6 +6,7 @@ import { createParser } from "@pipeline/parse";
 import { FileInput } from "@pipeline/parse/File";
 import { Parser } from "@pipeline/parse/Parser";
 import { PAuthor, PChannel, PGuild, PMessage, RawID } from "@pipeline/parse/Types";
+import { BigMap } from "@pipeline/process/BigMap";
 import { ChannelMessages } from "@pipeline/process/ChannelMessages";
 import { IndexCountsBuilder } from "@pipeline/process/IndexCounts";
 import { IndexedMap } from "@pipeline/process/IndexedMap";

--- a/pipeline/process/DatabaseBuilder.ts
+++ b/pipeline/process/DatabaseBuilder.ts
@@ -380,6 +380,7 @@ export class DatabaseBuilder {
                     }
 
                     msg.words = newWords.toArray();
+                    if (msg.words.length === 0) delete msg.words;
                 }
 
                 // store the address of the message

--- a/pipeline/serialization/IndexCountsSerialization.ts
+++ b/pipeline/serialization/IndexCountsSerialization.ts
@@ -54,6 +54,11 @@ export const writeIndexCounts = (counts: IndexCounts, stream: BitStream, bitsPer
         maxCount = Math.max(maxCount, c);
     }
 
+    // do we need to support this? I think not
+    if (len === 0) throw new Error("Cannot write empty IndexCounts");
+    if (total === 0) throw new Error("Cannot write IndexCounts with total 0");
+    if (maxCount === 0) throw new Error("Cannot write IndexCounts with maxCount 0");
+
     // check for single and double strategies
     if (total === 1) {
         stream.setBits(2, 0b00); // 0b00=single index

--- a/pipeline/serialization/MessageSerialization.ts
+++ b/pipeline/serialization/MessageSerialization.ts
@@ -50,7 +50,7 @@ export const writeMessage = (message: Message, stream: BitStream, bitConfig: Mes
     stream.setBits(bitConfig.authorIdxBits, message.authorIndex);
 
     let flags = MessageFlags.None;
-    if (message.replyOffset) flags |= MessageFlags.Reply;
+    if (message.replyOffset !== undefined) flags |= MessageFlags.Reply;
     if (message.editedAfter !== undefined) flags |= MessageFlags.Edited;
     if (message.langIndex !== undefined) flags |= MessageFlags.Text;
     if (message.words?.length) flags |= MessageFlags.Words;
@@ -61,11 +61,11 @@ export const writeMessage = (message: Message, stream: BitStream, bitConfig: Mes
     if (message.domains?.length) flags |= MessageFlags.Domains;
     stream.setBits(9, flags);
 
-    if (flags & MessageFlags.Reply) stream.writeVarInt(message.replyOffset!);
+    if (flags & MessageFlags.Reply) stream.writeVarInt(message.replyOffset!, 48);
     if (flags & MessageFlags.Edited) stream.writeVarInt(message.editedAfter!);
     if (flags & MessageFlags.Text) {
         stream.setBits(8, message.langIndex!); // 0-255
-        stream.setBits(8, message.sentiment! + 128); // 0-255
+        stream.setBits(8, Math.max(-128, Math.min(127, message.sentiment!)) + 128); // 0-255
     }
     if (flags & MessageFlags.Words) writeIndexCounts(message.words!, stream, bitConfig.wordIdxBits);
     if (flags & MessageFlags.Emojis) writeIndexCounts(message.emojis!, stream, bitConfig.emojiIdxBits);

--- a/tests/serialization/BitStream.test.ts
+++ b/tests/serialization/BitStream.test.ts
@@ -178,18 +178,35 @@ it("should get bits correctly after lots of sets", () => {
     }
 });
 
-test.each([7, 8, 9, 10, 11, 15, 16, 17, 20, 24, 31, 32])("varint %s bits should write and read correctly", (bits) => {
-    const cases: number[] = [0, 100, 200, 500, 1000, 5000, 10000, 100000, 2000000, 5000000, 1000000000].filter(
-        (v) => v < Math.pow(2, bits)
-    );
-    for (const value of cases) {
-        let s = new BitStream();
-        s.offset = 0;
-        s.writeVarInt(value, bits);
-        s.offset = 0;
-        expect(s.readVarInt(bits)).toBe(value);
+test.each([7, 8, 9, 10, 11, 15, 16, 17, 20, 24, 31, 32, 48])(
+    "varint %s bits should write and read correctly",
+    (bits) => {
+        const cases: number[] = [
+            0,
+            100,
+            200,
+            500,
+            1000,
+            5000,
+            10000,
+            100000,
+            2000000,
+            5000000,
+            1000000000,
+            2147483648 - 1,
+            2147483648 + 0,
+            2147483648 + 1,
+            2147483648 * 10,
+        ].filter((v) => v < Math.pow(2, bits) - 1);
+        for (const value of cases) {
+            let s = new BitStream();
+            s.offset = 0;
+            s.writeVarInt(value, bits);
+            s.offset = 0;
+            expect(s.readVarInt(bits)).toBe(value);
+        }
     }
-});
+);
 
 test("buffer8 returns a buffer aligned to 32bits", () => {
     const buf = new Uint32Array(1024);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2020",
     "module": "CommonJS",
     "jsx": "react-jsx",
 


### PR DESCRIPTION
This should fix #83.
I only replaced the Map that was producing the crash (the replies map)