### PR TITLE
Pseudo-remove Discord discriminators

### DIFF
--- a/pipeline/parse/parsers/DiscordParser.ts
+++ b/pipeline/parse/parsers/DiscordParser.ts
@@ -102,7 +102,7 @@ export class DiscordParser extends Parser {
         const pauthor: PAuthor = {
             id: message.author.id,
             bot: message.author.isBot,
-            name: name,
+            name,
             avatar: avatar ? (" " + avatar).substring(1) : undefined, // avoid leak
         };
         this.emit("author", pauthor, this.lastMessageTimestampInFile);

--- a/pipeline/parse/parsers/DiscordParser.ts
+++ b/pipeline/parse/parsers/DiscordParser.ts
@@ -82,9 +82,13 @@ export class DiscordParser extends Parser {
         const timestampEdit = message.timestampEdited ? Date.parse(message.timestampEdited) : undefined;
         const callEndedTimestamp = message.callEndedTimestamp ? Date.parse(message.callEndedTimestamp) : undefined;
 
-        // Discord allows users to have different nicknames depending the chat. We honor the nickname first
-        const name = message.author.nickname || message.author.name;
-        const isDeletedUser = name === "Deleted User";
+        // Discord allows users to have different nicknames depending on the chat. We honor the nickname first
+        let name = message.author.nickname || message.author.name;
+        if (name === "Deleted User") {
+            name = name.concat(" #" + message.author.id);
+        } else if (message.author.discriminator !== "0000") {
+            name = name.concat("#" + message.author.discriminator);
+        }
 
         // About the avatar:
         // See: https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints
@@ -98,7 +102,7 @@ export class DiscordParser extends Parser {
         const pauthor: PAuthor = {
             id: message.author.id,
             bot: message.author.isBot,
-            name: name + (isDeletedUser ? " #" + message.author.id : "#" + message.author.discriminator),
+            name: name,
             avatar: avatar ? (" " + avatar).substring(1) : undefined, // avoid leak
         };
         this.emit("author", pauthor, this.lastMessageTimestampInFile);

--- a/report/components/core/labels/AuthorLabel.tsx
+++ b/report/components/core/labels/AuthorLabel.tsx
@@ -25,14 +25,13 @@ const _AuthorLabel = ({ index }: LabelProps) => {
         if (discr && discr.length === 4) {
             discr = parseInt(discr).toString();
             n = n.slice(0, -5);
-        } else discr = undefined;
-
-        name = (
-            <>
-                {n}
-                {discr && <span className="Label__discriminator">#{`${isDemo ? 0 : discr}`.padStart(4, "0")}</span>}
-            </>
-        );
+            name = (
+                <>
+                    {n}
+                    {discr && <span className="Label__discriminator">#{`${isDemo ? 0 : discr}`.padStart(4, "0")}</span>}
+                </>
+            );
+        }
     }
 
     if (author.b) {

--- a/report/components/core/labels/AuthorLabel.tsx
+++ b/report/components/core/labels/AuthorLabel.tsx
@@ -18,14 +18,16 @@ const _AuthorLabel = ({ index }: LabelProps) => {
 
     // add discriminator in Discord
     if (db.config.platform === "discord") {
-        const discr = author.n.split("#").pop();
+        const parts = author.n.split("#");
+        const nick = parts[0];
+        const discr: string | undefined = parts[1];
 
         // only keep if it's 4 chars (and not a deleted ID)
-        if (discr && discr.length === 4) {
+        if (!isDemo && discr && discr.length === 4) {
             name = (
                 <>
-                    {author.n.slice(0, -5)}
-                    <span className="Label__discriminator">#{`${isDemo ? "0000" : discr}`}</span>
+                    {nick}
+                    <span className="Label__discriminator">#{discr}</span>
                 </>
             );
         }

--- a/report/components/core/labels/AuthorLabel.tsx
+++ b/report/components/core/labels/AuthorLabel.tsx
@@ -18,17 +18,14 @@ const _AuthorLabel = ({ index }: LabelProps) => {
 
     // add discriminator in Discord
     if (db.config.platform === "discord") {
-        let n = author.n;
-        let discr = n.split("#").pop();
+        const discr = author.n.split("#").pop();
 
         // only keep if it's 4 chars (and not a deleted ID)
         if (discr && discr.length === 4) {
-            discr = parseInt(discr).toString();
-            n = n.slice(0, -5);
             name = (
                 <>
-                    {n}
-                    {discr && <span className="Label__discriminator">#{`${isDemo ? 0 : discr}`.padStart(4, "0")}</span>}
+                    {author.n.slice(0, -5)}
+                    <span className="Label__discriminator">#{`${isDemo ? "0000" : discr}`}</span>
                 </>
             );
         }


### PR DESCRIPTION
Technically the Discord API still supports discriminators, and I am still a strong advocate for supporting legacy exports to a limited extent, so I don't think support for them should be removed entirely. However, having the #0000 at the end of every username is a bit redundant. May want to consider adding a "@" before the username, but that's really up to personal preference so I haven't included it