### PR TITLE
Allow multiple calls at the same time

### DIFF
--- a/pipeline/aggregate/blocks/calls/CallsStats.ts
+++ b/pipeline/aggregate/blocks/calls/CallsStats.ts
@@ -65,7 +65,7 @@ const fn: BlockFn<CallsStats> = (database, filters, common, args) => {
             // compute time difference between calls
             let diff = diffDatetime(lastCall, startDatetime);
             if (diff < 0) {
-                secondsInCall += diff; // Remove overlap
+                secondsInCall -= diff; // remove overlap
                 diff = 0;
             }
             timesBetween[total - 1] = diff;

--- a/pipeline/aggregate/blocks/calls/CallsStats.ts
+++ b/pipeline/aggregate/blocks/calls/CallsStats.ts
@@ -1,8 +1,6 @@
 import { Datetime, diffDatetime } from "@pipeline/Time";
 import { BlockDescription, BlockFn } from "@pipeline/aggregate/Blocks";
 import { VariableDistribution, computeVariableDistribution } from "@pipeline/aggregate/Common";
-import { filterMessages } from "@pipeline/aggregate/Helpers";
-import { MessageView } from "@pipeline/serialization/MessageView";
 
 interface CallDuration {
     duration: number;
@@ -65,8 +63,11 @@ const fn: BlockFn<CallsStats> = (database, filters, common, args) => {
 
         if (lastCall !== undefined) {
             // compute time difference between calls
-            const diff = diffDatetime(lastCall, startDatetime);
-            if (diff < 0) throw new Error("Time difference between calls is negative, diff=" + diff);
+            let diff = diffDatetime(lastCall, startDatetime);
+            if (diff < 0) {
+                secondsInCall += diff; // Remove overlap
+                diff = 0;
+            }
             timesBetween[total - 1] = diff;
         }
         lastCall = endDatetime;


### PR DESCRIPTION
It's usually safe to assume that a call cannot be started when the last one hasn't ended yet, but this doesn't work if importing multiple chats. I could be in a call with someone but receive a call from someone else, or I could be in two group chats which happened to have an active call at the same time.