### PR TITLE
Allow custom paths in Discord avatars

### DIFF
--- a/pipeline/parse/parsers/DiscordParser.ts
+++ b/pipeline/parse/parsers/DiscordParser.ts
@@ -95,9 +95,20 @@ export class DiscordParser extends Parser {
         // Can be:
         // - https://cdn.discordapp.com/avatars/user_id/user_avatar.png (custom avatar, we only care about `user_id/user_avatar`)
         // - https://cdn.discordapp.com/embed/avatars/discriminator.png (default color avatar)
+        // - <path>.png/gif (custom avatar but stored using `--media=true` in DCE)
         let avatar: string | undefined;
-        if (message.author.avatarUrl && message.author.avatarUrl.includes("discordapp.com/avatars"))
-            avatar = message.author.avatarUrl.slice(35).split(".")[0];
+        if (message.author.avatarUrl) {
+            if (message.author.avatarUrl.includes("discordapp.com/avatars")) {
+                // custom avatar as URL, extract "user_id/user_avatar"
+                avatar = message.author.avatarUrl.slice(35).split(".")[0];
+            } else if (!message.author.avatarUrl.startsWith("http")) {
+                // assume it's a custom avatar stored as media
+                // store the full path to the avatar
+                // note that this will not work unless the user puts the report.html in the correct
+                // folder, but since we don't have the online URL, we do this as best-effort
+                avatar = message.author.avatarUrl;
+            }
+        }
 
         const pauthor: PAuthor = {
             id: message.author.id,

--- a/report/components/core/avatars/AuthorAvatar.tsx
+++ b/report/components/core/avatars/AuthorAvatar.tsx
@@ -45,7 +45,16 @@ export const AuthorAvatar = ({ index }: { index: number }) => {
             const num = author.n.split("#").pop();
             if (num && num.length === 4) discriminator = parseInt(num);
 
-            url = author.a ? `https://cdn.discordapp.com/avatars/${author.a}.png?size=64` : undefined;
+            if (author.a) {
+                if (!author.a.includes(".")) {
+                    // author.a is the "user_id/user_avatar" of the avatar URL
+                    // for example "840286670888370206/7a0ce959e13e749f4f4d93ea4b314b9c"
+                    url = `https://cdn.discordapp.com/avatars/${author.a}.png?size=64`;
+                } else {
+                    // author.a is the full path to the avatar (probably locally stored)
+                    url = author.a;
+                }
+            }
             placeholder = RawImg(DiscordDefaultDMAvatars[discriminator % 5]);
             break;
         case "telegram":


### PR DESCRIPTION
This will load avatars from local directories if exports have media files enabled. Fixes #106