### PR TITLE
Correct json array parsing

### DIFF
--- a/pipeline/parse/JSONStream.ts
+++ b/pipeline/parse/JSONStream.ts
@@ -222,8 +222,11 @@ export class JSONStream {
                     break;
 
                 case State.END_VALUE_ARRAY:
-                    // console.log("EMITTING ARRAY", this.key, this.value);
-                    this.arrayCallbacks[this.key!](this.parseValue());
+                    // Check if the captured value is actually empty/whitespace
+                    if (this.buffer.slice(this.valueStart, i).trim().length > 0) {
+                        // console.log("EMITTING ARRAY", this.key, this.value);
+                        this.arrayCallbacks[this.key!](this.parseValue());
+                    }
 
                     // read next item
                     this.state = State.NEXT_ARRAY_ITEM;

--- a/tests/parse/Parsers.test.ts
+++ b/tests/parse/Parsers.test.ts
@@ -14,6 +14,7 @@ import { loadSample } from "@tests/samples";
 describe("should parse correctly", () => {
     // prettier-ignore
     const cases: { parser: new () => Parser; inputs: string[] }[] = [
+        { parser: DiscordParser, inputs: ["discord/DM_0A_0M.json"] },
         { parser: DiscordParser, inputs: ["discord/DM_2A_2M.json"] },
         { parser: DiscordParser, inputs: ["discord/GC_3A_5M.json"] },
         { parser: DiscordParser, inputs: ["discord/SV_5A_5M.json"] },

--- a/tests/samples/discord/DM_0A_0M.json
+++ b/tests/samples/discord/DM_0A_0M.json
@@ -1,0 +1,21 @@
+{
+    "guild": {
+        "id": "0",
+        "name": "Direct Messages",
+        "iconUrl": "https://cdn.discordapp.com/embed/avatars/0.png"
+    },
+    "channel": {
+        "id": "530805775262679064",
+        "type": "DirectTextChat",
+        "categoryId": "0",
+        "category": "Private",
+        "name": "Someones name",
+        "topic": null
+    },
+    "dateRange": {
+        "after": null,
+        "before": null
+    },
+    "messages": [],
+    "messageCount": 0
+}

--- a/tests/samples/discord/DM_0A_0M.json.ts
+++ b/tests/samples/discord/DM_0A_0M.json.ts
@@ -1,0 +1,16 @@
+import type { ExpectedPartialParseResult } from "@tests/parse/Parse";
+import { PGUILD_DM } from "@tests/samples/discord/Common";
+
+export const expectedParse: ExpectedPartialParseResult = {
+    guilds: [PGUILD_DM],
+    channels: [
+        {
+            id: "530805775262679064",
+            type: "dm",
+            avatar: undefined,
+        },
+    ],
+    authors: [],
+    messages: [],
+    calls: [],
+};


### PR DESCRIPTION
When JSONStream tries to read an empty array, it failed because it was trying to parse the empty string. To correct this, we just need to double check in `State.END_VALUE_ARRAY` that there's actually something to parse.

When DiscordChatExporter encounters an empty channel (or DM, voice chat, or otherwise), it still creates a file, but the `messages` field is set to `[]`. This fix makes sure that we can still parse it.

Also included tests for this case.

Related: https://github.com/mlomb/chat-analytics/issues/139